### PR TITLE
Call glXWaitX before we start drawing

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -1022,6 +1022,9 @@ eventLoop (void)
 
 					makeScreenCurrent (s);
 
+					/* make sure X is ready for us to draw */
+					glXWaitX ();
+
 					if (s->slowAnimations)
 					{
 						(*s->preparePaintScreen) (s,


### PR DESCRIPTION
Call glXWaitX before we start drawing to make sure X is done
handling rendering calls. Suggested by Michel Dänzer to ensure
we don't have any rendering glitches.
Origin: vendor, ubuntu (1:0.8.3+git20090917-0ubuntu3)
Author: Travis Watkins <amaranth@ubuntu.com>

fixes https://github.com/noodlylight/fusilli/issues/17