### PR TITLE
kde4-decorator: add x11 as a necessary dep

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,7 @@ if test "x$use_kde4" = "xyes"; then
 
   if test -d "$kde4libs"; then
     PKG_CHECK_MODULES(FUSILLI_DECORATOR_KDE4,
-                      dbus-1 xdamage xext xcomposite QtCore >= 4.5.0 QtGui QtDBus,
+                      dbus-1 x11 xdamage xext xcomposite QtCore >= 4.5.0 QtGui QtDBus,
                       [use_kde4=yes], [use_kde4=no])
 
     KDE4_CFLAGS="-I$kde4incs"


### PR DESCRIPTION
I needed this on Debian jessie in order to link properly.

I'm still having trouble with the linking of other things. I'll probably submit more patches as I figure it out. For some reason, libdecoration.so is linking to itself and ldd is unable to resolve this.

Aside, upstream compiz has a CMake build. Do you prefer autotools?